### PR TITLE
ACE 3 revive system

### DIFF
--- a/missionConfig/bmt_components_addons.hpp
+++ b/missionConfig/bmt_components_addons.hpp
@@ -17,7 +17,7 @@
 #include "..\src\acre2\bmt_acre2.hpp"       // Functions to initialise and configure ACRE 2.
 #include "asrai3\bmt_asrai3.hpp"            // Functions to configure ASR AI 3.
 #include "..\src\dac\bmt_dac.hpp"           // Functions to configure DAC.
-//#include "..\src\t8units\bmt_t8units.hpp"   // Functions to configure T8 Units.
+#include "..\src\t8units\bmt_t8units.hpp"   // Functions to configure T8 Units.
 #include "..\src\tfar\bmt_tfar.hpp"         // Functions to initialise and configure TFAR.
 
 //============================================= END OF FILE =============================================//

--- a/src/ace3/bmt_ace3.hpp
+++ b/src/ace3/bmt_ace3.hpp
@@ -21,6 +21,7 @@
         class ace3_assignWounds {};
         class ace3_config_preInit  { PreInit = 1; };
         class ace3_config_postInit { PostInit = 1; };
+        class ace3_config_revive   { PostInit = 1; };
     };
 #endif
 
@@ -45,6 +46,17 @@
         values[] = {0, 1, 2};
         texts[] = {"Disabled", "Basic", "Advanced"};
         default = BMT_ACE3_MEDICAL;
+    };
+
+    //===================================================================================================//
+    // Medical sistem: Level of detail of the ACE3 medical system.                                       //
+    // Default option: Advanced.                                                                         //
+    //===================================================================================================//
+    class bmt_param_ace3_reviveSystem {
+        title = "Revive system";
+        values[] = {0, 1, 2};
+        texts[] = {"Disabled", "Players only", "Players and AI"};
+        default = BMT_ACE3_REVIVE;
     };
 
     //===================================================================================================//

--- a/src/ace3/functions/fn_ace3_config_preInit.sqf
+++ b/src/ace3/functions/fn_ace3_config_preInit.sqf
@@ -146,6 +146,8 @@ if (isClass (configFile >> "CfgPatches" >> "ace_map_gestures")) then {
 
 if (isClass (configFile >> "CfgPatches" >> "ace_medical")) then {
 
+    private _numRespawns =  getNumber (missionConfigFile >> "bmt_config" >> "bmt_config_numAllowedRespawns");
+
     //====================================================================================================//
     // ACE3 Medical: http://ace3mod.com/wiki/missionmaker/modules.html#2.-ace3-medical                    //
     //====================================================================================================//
@@ -166,9 +168,16 @@ if (isClass (configFile >> "CfgPatches" >> "ace_medical")) then {
     ["ace_medical_enableUnconsciousnessAI", 1.0, true, true] call ACE_common_fnc_setSetting;                   // 0 = Disabled, 1* = 50/50, 2 = Enabled.
     ["ace_medical_remoteControlledAI", true, true, true] call ACE_common_fnc_setSetting;                       // 0 = Disabled, 1* = Enabled.
     ["ace_medical_preventInstaDeath", false, true, true] call ACE_common_fnc_setSetting;                       // 0* = Disabled, 1 = Enabled.
-    ["ace_medical_enableRevive", 0.0, true, true] call ACE_common_fnc_setSetting;                              // 0* = Disabled, 1 = Only players, 2 = Players and AI.
+
+    // Revive sistem
+    ["ace_medical_enableRevive", bmt_param_ace3_reviveSystem, true, true] call ACE_common_fnc_setSetting;                              // 0* = Disabled, 1 = Only players, 2 = Players and AI.
     ["ace_medical_maxReviveTime", 120.0, true, true] call ACE_common_fnc_setSetting;                           // Scalar. 120 = Default value.
-    ["ace_medical_amountOfReviveLives", -1.0, true, true] call ACE_common_fnc_setSetting;                      // Scalar. -1 = Default value.
+    if ( (_numRespawns > 0) && (bmt_param_ace3_reviveSystem > 0) ) then {
+        ["ace_medical_amountOfReviveLives", -1.0, true, true] call ACE_common_fnc_setSetting;                      // Scalar. -1 = Default value.
+    } else {
+        ["ace_medical_amountOfReviveLives", -1.0, true, true] call ACE_common_fnc_setSetting;                      // Scalar. -1 = Default value.
+    };
+
     ["ace_medical_allowDeadBodyMovement", false, true, true] call ACE_common_fnc_setSetting;                   // 0* = Disabled, 1 = Enabled.
     ["ace_medical_allowLitterCreation", true, true, true] call ACE_common_fnc_setSetting;                      // 0 = Disabled, 1* = Enabled.
     // ["ace_medical_litterSimulationDetail", 3.0, false, false] call ACE_common_fnc_setSetting;               // Client side. 0 = Disabled (0), 1 = Baix(50), 2 = Mitjà (100), 3* = Alt (1000), 4 = Ultra (5000).

--- a/src/ace3/functions/fn_ace3_config_revive.sqf
+++ b/src/ace3/functions/fn_ace3_config_revive.sqf
@@ -1,0 +1,40 @@
+//=======================================================================================================//
+// File: fn_ace3_config_preInit.sqf                                                                      //
+// Author: TheMagnetar                                                                                   //
+// Version 1.1                                                                                           //
+// File creation: 2015/05/28                                                                             //
+// Description: This document is used for configuring a mission with ACE 3 without requiring to place    //
+//              modules in the editor manually.                                                          //
+//              http://ace3mod.com/wiki/index.html                                                       //
+//              http://ace3mod.com/wiki/missionmaker/modules.html                                        //
+// Changes: 1.0 (2015/11/26) First public version.                                                       //
+//=======================================================================================================//
+
+private _numRespawns =  getNumber (missionConfigFile >> "bmt_config" >> "bmt_config_numAllowedRespawns");
+
+if (bmt_param_ace3_reviveSystem > 0) then {
+    _numRespawns = 0;
+
+    // If ACE3's revive system is used, disable respawns themselves.
+    switch (bmt_param_respawn_tickets) do {
+        case 0: {
+            if (bmt_param_debugOutput == 1) then {
+                player sidechat format ["DEBUG (fn_ace3_config_revive.sqf): Disabling respawning per side in favour of ACE3 revive system."];
+            };
+            switch (side player) do {
+                case west: { _pos = 0; };
+                case east: { _pos = 1; };
+                case resistance: { _pos = 2; };
+                case civilian: { _pos = 3; };
+            };
+            bmt_array_numRespawns set [_pos, _numRespawns];
+            publicVariable bmt_array_numRespawns;
+        };
+        case 1: {
+            if (bmt_param_debugOutput == 1) then {
+                player sidechat format ["DEBUG (fn_ace3_config_revive.sqf): Disabling player respawn in favour of ACE3 revive system."];
+            };
+            player setVariable ["bmt_var_numRespawns", _numRespawns, true];
+        };
+    };
+};


### PR DESCRIPTION
This system, expands the old one. At mission start one can select to enable ACE3 Revive system. In addition this will:

1. Change the amount of revives to the mission defined variable `bmt_config_numAllowedRespawns`.
2. Vanilla respawn will then be disabled. If the amount of revives in ace3 is spent and/or the unit bleeds out, the player will suffer permanent death will enter spectator mode.

Question: Should point 2 be made optional? Personally I am not inclined to having two "respawns" systems. One should be sufficient.

