### PR TITLE
Fixes for RC3

### DIFF
--- a/bmt_components.hpp
+++ b/bmt_components.hpp
@@ -12,6 +12,7 @@
 
 // Genaral functions and scripts.
 #include "src\core\bmt_core.hpp"                       // Core and essential functions for the correct execution of scripts.
+#include "src\briefing\bmt_briefing.hpp"               // Briefing related functions.
 #include "src\configEquipment\bmt_configEquipment.hpp" // Loadout and equipment related functions.
 #include "src\configGroup\bmt_configGroup.hpp"         // Group configuration functions.
 #include "src\configUnit\bmt_configUnit.hpp"           // Unit configuration functions.

--- a/missionConfig/briefing/scripts/bmt_briefing_admin.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_admin.sqf
@@ -15,7 +15,6 @@
 private ["_briefingAdmin", "_briefingNotes", "_briefingEndings", "_briefingJip"];
 private ["_respawnDescription", "_respawnType", "_respawnTickets"];
 private ["_debriefingEntries", "_endingEntry", "_endingTitle", "_endingDescription"];
-private
 
 //=======================================================================================================//
 // MESSAGES ONLY SHOWN TO THE ADMINISTRATOR.                                                             //

--- a/missionConfig/briefing/scripts/bmt_briefing_blu_ctrg_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_blu_ctrg_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_blu_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_blu_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_blu_gen_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_blu_gen_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_blu_t_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_blu_t_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_bwa3_faction.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_bwa3_faction.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_civ_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_civ_f.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_fia_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_fia_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_ind_c_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_ind_c_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_ind_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_ind_f.sqf
@@ -26,33 +26,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_opf_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_opf_f.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_opf_t_f.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_opf_t_f.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_insurgents.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_insurgents.sqf
@@ -28,33 +28,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_usarmy_d.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_usarmy_d.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_usarmy_wd.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_usarmy_wd.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_usmc_d.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_usmc_d.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_usmc_wd.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_usmc_wd.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_usn.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_usn.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_vdv.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_vdv.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/briefing/scripts/bmt_briefing_rhs_vpvo.sqf
+++ b/missionConfig/briefing/scripts/bmt_briefing_rhs_vpvo.sqf
@@ -27,33 +27,7 @@ With the collaboration of Magnetar (A3-BMT template) and *** possible collaborat
 //=======================================================================================================//
 // NOTES: RADIO.                                                                                         //
 //=======================================================================================================//
-_radio = player createDiaryRecord ["diary", ["Radio frequencies","
-<font color='#FF0000' size='18'>Command</font>: 41 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>CAS</font>: 51 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Artillery</font>: 61 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Alpha</font>
-<br/>
-- Squad ""Alpha 1"": 200 kHz.
-<br/>
-- Fireteam ""Alpha 1-1"": 201 kHz.
-<br/>
-- Fireteam ""Alpha 1-2"": 202 kHz.
-<br/>
-- Fireteam ""Alpha 1-3"": 203 kHz.
-<br/><br/>
-<font color='#FF0000' size='18'>Bravo</font>
-<br/>
-- Squad ""Bravo 1"": 210 kHz.
-<br/>
-- Fireteam ""Bravo 1-1"": 211 kHz.
-<br/>
-- Fireteam ""Bravo 1-2"": 212 kHz.
-<br/>
-- Fireteam ""Bravo 1-3"": 213 kHz.
-"]];
+_radio = player createDiaryRecord ["diary", ["Radio frequencies", [] call bmt_fnc_briefing_listRadioFrequencies]];
 
 //=======================================================================================================//
 // NOTES: ADMINISTRATION/LOGISTICS.                                                                       //

--- a/missionConfig/tfar/scripts/bmt_tfar_configuration.sqf
+++ b/missionConfig/tfar/scripts/bmt_tfar_configuration.sqf
@@ -25,6 +25,9 @@ tf_same_lr_frequencies_for_side = true;
 // Assign watch (false) or microDAGR (true).
 tf_give_microdagr_to_soldier = true;
 
+// Commanding group.
+bmt_var_tfar_commandingGroup = "Command";
+
 // Radios to be distributed among the units.
 // [Long range radio, short range radio, rifleman radio]
 bmt_list_tfar_radiosWest = ["tf_rt1523g_big_rhs", TF_defaultWestPersonalRadio, TF_defaultWestRiflemanRadio];

--- a/src/ace3/functions/fn_ace3_config_revive.sqf
+++ b/src/ace3/functions/fn_ace3_config_revive.sqf
@@ -40,10 +40,14 @@ if (bmt_param_ace3_reviveSystem > 0) then {
     // Set the number of ACE Revives to be equal to the original respawn tickets
     if (_numRevives > 0) then {
         player setVariable ["ace_medical_amountOfReviveLives", _numRevives, true];
-        player sidechat format ["DEBUG (fn_ace3_config_revive.sqf): Player has %1 ACE 3 Revives.", _numRevives];
+        if (bmt_param_debugOutput == 1) then {
+            player sidechat format ["DEBUG (fn_ace3_config_revive.sqf): Player has %1 ACE 3 Revives.", _numRevives];
+        };
     } else {
         player setVariable ["ace_medical_amountOfReviveLives", -1, true]; // Unlimited revives.
-        player sidechat format ["DEBUG (fn_ace3_config_revive.sqf): Player has unlimited ACE 3 Revives."];
+        if (bmt_param_debugOutput == 1) then {
+            player sidechat format ["DEBUG (fn_ace3_config_revive.sqf): Player has unlimited ACE 3 Revives."];
+        };
     };
 };
 

--- a/src/acre2/functions/fn_acre2_configureChannels.sqf
+++ b/src/acre2/functions/fn_acre2_configureChannels.sqf
@@ -54,18 +54,13 @@ _channel = 1;
 _radioList = call acre_api_fnc_getCurrentRadioList;
 {
 
-    // PRC343 radios active channel defaults to the one associated to the fireteam.
-    if ([_x, "ACRE_PRC343"] call acre_api_fnc_isKindOf) then {
+    // PRC343 or SEM 52 SL radios active channel defaults to the one associated to the fireteam.
+    if ([_x, "ACRE_PRC343"] call acre_api_fnc_isKindOf || [_x, "ACRE_SEM52SL"] call acre_api_fnc_isKindOf) then {
         [_x, _fireteamChannel] call acre_api_fnc_setRadioChannel;
     };
 
-    // PRC148 radios active channel defaults to the squad net.
-    if ([_x, "ACRE_PRC148"] call acre_api_fnc_isKindOf) then {
-        [_x, _squadChannel] call acre_api_fnc_setRadioChannel;
-    };
-
-    // PRC152 radios active channel defaults to the squad net.
-    if ([_x, "ACRE_PRC152"] call acre_api_fnc_isKindOf) then {
+    // PRC148 and PRC152 radios active channel defaults to the squad net.
+    if ([_x, "ACRE_PRC148"] call acre_api_fnc_isKindOf || [_x, "ACRE_PRC152"] call acre_api_fnc_isKindOf) then {
         [_x, _squadChannel] call acre_api_fnc_setRadioChannel;
     };
 

--- a/src/acre2/functions/fn_acre2_configurePresets.sqf
+++ b/src/acre2/functions/fn_acre2_configurePresets.sqf
@@ -12,9 +12,9 @@
 // Changes: 1.0 (2015/11/26) First public version.                                                       //
 //=======================================================================================================//
 
-private["_radioList", "_nameList", "_presetList", "_radio", "_presetName", "_name", "_channelName", "_channel", "_presetData"];
+private["_radioList", "_nameList", "_presetList", "_frequencyList", "_radio", "_presetName", "_name", "_channelName", "_channel", "_presetData"];
 
-_radioList = ["ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F"];
+_radioList = ["ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F","ACRE_SEM52SL"];
 _nameList = ["label", "description", "name"];
 _presetList = ["default2","default3","default4"];
 
@@ -26,11 +26,25 @@ _presetList = ["default2","default3","default4"];
         _channel = 1;
         {
             _channelName = _x;
-            _frequencies = bmt_array_frequenciesShortRange select _forEachIndex;
+            _frequencyList = bmt_array_frequenciesShortRange select _forEachIndex;
             {
-                [_radio, _presetName, _channel, _name, toUpper (_channelName select _forEachIndex)] call acre_api_fnc_setPresetChannelField;
-                [_radio, _presetName, _channel, "frequencyTX", _frequencies select _forEachIndex] call acre_api_fnc_setPresetChannelField;
-                [_radio, _presetName, _channel, "frequencyRX", _frequencies select _forEachIndex] call acre_api_fnc_setPresetChannelField;
+                _channelFrequency = _frequencyList select _forEachIndex;
+                if (_radio == "ACRE_SEM52SL") then {
+                    if (_channel < 12) then {
+                        if ((_channelFrequency < 46.000) OR (_channelFrequency > 65.975)) then {
+                            player sideChat format ["WARNING (fn_acre2_configurePresets.sqf): Channel frequency for channel %1 out of range for SEM-52SL. It should be between 46.000 and 65.975 but it is %2.", _channel, _channelFrequency];
+                        } else {
+                            [_radio, _presetName, _channel, "frequencyTX", _channelFrequency] call acre_api_fnc_setPresetChannelField;
+                            [_radio, _presetName, _channel, "frequencyRX", _channelFrequency] call acre_api_fnc_setPresetChannelField;
+                        };
+                    } else {
+                        player sideChat format ["WARNING (fn_acre2_configurePresets.sqf): Too many frequencies to configure for SEM-52SL radio."];
+                    };
+                } else {
+                    [_radio, _presetName, _channel, _name, toUpper (_channelName select _forEachIndex)] call acre_api_fnc_setPresetChannelField;
+                    [_radio, _presetName, _channel, "frequencyTX", _channelFrequency] call acre_api_fnc_setPresetChannelField;
+                    [_radio, _presetName, _channel, "frequencyRX", _channelFrequency] call acre_api_fnc_setPresetChannelField;
+                };
                 _channel = _channel + 1;
             } forEach _channelName;
         } forEach bmt_array_groups;

--- a/src/acre2/functions/fn_acre2_configurePresets.sqf
+++ b/src/acre2/functions/fn_acre2_configurePresets.sqf
@@ -14,9 +14,13 @@
 
 private["_radioList", "_nameList", "_presetList", "_frequencyList", "_radio", "_presetName", "_name", "_channelName", "_channel", "_presetData"];
 
-_radioList = ["ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F","ACRE_SEM52SL"];
+_radioList = ["ACRE_PRC148","ACRE_PRC152","ACRE_PRC117F"];
 _nameList = ["label", "description", "name"];
 _presetList = ["default2","default3","default4"];
+
+if (bmt_acre2_riflemanRadio == "ACRE_SEM52SL" || bmt_acre2_shortRangeRadio == "ACRE_SEM52SL" || bmt_acre2_longRangeRadio == "ACRE_SEM52SL") then {
+    _radioList pushBack "ACRE_SEM52SL";
+};
 
 {
     _radio = _x;

--- a/src/acre2/scripts/bmt_acre2_initClient.sqf
+++ b/src/acre2/scripts/bmt_acre2_initClient.sqf
@@ -30,6 +30,7 @@ if (bmt_acre2_differentPresets) then {
 ["ACRE_PRC148", _presetName] call acre_api_fnc_setPreset;
 ["ACRE_PRC152", _presetName] call acre_api_fnc_setPreset;
 ["ACRE_PRC117F", _presetName] call acre_api_fnc_setPreset;
+["ACRE_SEM52SL", _presetName] call acre_api_fnc_setPreset;
 
 // Configure ACRE2. If player is alive then radios will be removed to be added later depending on the role
 // as defined in "bmt_acre2_configuracio.sqf". Spectator chat will be force if unit is not alive.

--- a/src/briefing/bmt_briefing.hpp
+++ b/src/briefing/bmt_briefing.hpp
@@ -1,0 +1,25 @@
+//=======================================================================================================//
+// File: bmt_acre2.hpp                                                                                   //
+// Author: TheMagnetar                                                                                   //
+// Version: 1.0                                                                                          //
+// File creation: 2016/12/17                                                                             //
+// Description: This file declares the functions that will be available if this module is used during    //
+//              the mission. In this case it declares functions related to radio configuration a the     //
+//              briefing screen.                                                                         //
+// Changes: 1.0 (2015/11/26) First public version.                                                       //
+//=======================================================================================================//
+
+// Especifies that this component has been loaded.
+#ifdef BMT_COMPONENTS
+    class briefing {};
+#endif
+
+// Define the functions of this component.
+#ifdef BMT_FUNCTIONS_INTERNAL
+    class briefing {
+        file = "src\briefing\functions";
+        class briefing_listRadioFrequencies { };
+    };
+#endif
+
+//============================================= END OF FILE =============================================//

--- a/src/briefing/functions/fn_briefing_listRadioFrequencies.sqf
+++ b/src/briefing/functions/fn_briefing_listRadioFrequencies.sqf
@@ -1,0 +1,51 @@
+//=======================================================================================================//
+// File: fn_briefing_listRadioFrequencies.sqf                                                            //
+// Author: TheMagnetar                                                                                   //
+// Version: 1.0                                                                                          //
+// File creation: 17/16/2016                                                                             //
+// Description: Function to list radio frequencies in the briefing.                                      //
+//                                                                                                       //
+//              Arguments:                                                                               //
+//               - none                                                                                  //
+//                                                                                                       //
+// Changes:  1.0 (2016/12/17) First public version.                                                      //
+//=======================================================================================================//
+
+private ["_shortRangeFrequencies", "_longRangeFrequencies", "_teamList", "_frequencySRList", "_frequencyLRList", "_frequency", "_team", "_radioFrequencies", "_channel", "_block"];
+
+_shortRangeFrequencies = ""; _longRangeFrequencies = "";
+_channel = 1; _block = 1;
+{
+    _teamList = _x;
+    _frequencySRList = bmt_array_frequenciesShortRange select _forEachIndex;
+    _frequencyLRList = bmt_array_frequenciesLongRange select _forEachIndex;
+
+    {
+        _frequency = _frequencySRList select _forEachIndex;
+        _team = _teamList select _forEachIndex;
+        if (_forEachIndex == 0) then {
+            _shortRangeFrequencies = _shortRangeFrequencies + format ["<font color='#00FFFF'>%1:</font> %2 MHz.", _team, _frequency];
+            player sideChat format ["F; %1", _shortRangeFrequencies];
+        } else {
+            _shortRangeFrequencies = _shortRangeFrequencies + format ["     <font color='#00FFFF'>%1:</font> %2 MHz.", _team, _frequency];
+        };
+
+        if (bmt_mod_acre2) then {
+            _shortRangeFrequencies =  _shortRangeFrequencies + format [" AN/PRC 343 on block %1 channel %2.<br/>", _block, _channel];
+        } else {
+            _shortRangeFrequencies =  _shortRangeFrequencies + ".<br/>";
+        };
+
+        _channel = _channel + 1;
+        if (_channel > 16) then {
+            _channel = 1; _block = _block + 1;
+        };
+    } forEach _teamList;
+    _shortRangeFrequencies = _shortRangeFrequencies + "<br/>";
+
+    _longRangeFrequencies = _longRangeFrequencies + format ["<font color='#00FFFF'>%1:</font> %2 MHz.<br/>", _teamList select 0, _frequencyLRList select 0];
+} forEach bmt_array_groups;
+
+_radioFrequencies = format ["<font color='#FF0000' size='18'>Short Range Radios</font><br/><br/>%1<font color='#FF0000' size='18'>Long Range Radios</font><br/><br/>%2", _shortRangeFrequencies, _longRangeFrequencies];
+
+_radioFrequencies

--- a/src/briefing/functions/fn_briefing_listRadioFrequencies.sqf
+++ b/src/briefing/functions/fn_briefing_listRadioFrequencies.sqf
@@ -25,7 +25,6 @@ _channel = 1; _block = 1;
         _team = _teamList select _forEachIndex;
         if (_forEachIndex == 0) then {
             _shortRangeFrequencies = _shortRangeFrequencies + format ["<font color='#00FFFF'>%1:</font> %2 MHz.", _team, _frequency];
-            player sideChat format ["F; %1", _shortRangeFrequencies];
         } else {
             _shortRangeFrequencies = _shortRangeFrequencies + format ["     <font color='#00FFFF'>%1:</font> %2 MHz.", _team, _frequency];
         };

--- a/src/configGroup/functions/fn_configGroup.sqf
+++ b/src/configGroup/functions/fn_configGroup.sqf
@@ -27,7 +27,7 @@ _unit setVariable ["bmt_var_unitGroup", [_groupName, _subgroupIndex], true];
 // Configure chat if the group is defined.
 if (!isNil "_groupName") then {
     _group = group _unit;
-    if (_subgroupIndex != -1) then {
+    if (_subgroupIndex != 0) then {
         _group setGroupId [format["%1-%2", _groupName, _subgroupIndex], "GroupColor0"];
     } else {
       _group setGroupId [format["%1", _groupName], "GroupColor0"];

--- a/src/dac/functions/fn_dac_init.sqf
+++ b/src/dac/functions/fn_dac_init.sqf
@@ -17,26 +17,26 @@
 
 if (!bmt_mod_dac OR (bmt_param_dac_enabled == 0)) exitWith {};
 
-if (isServer) then {
-    // Create DAC necessary "DAC_Source_Extern" logic module.
-    if (isNil "bmt_var_centreSideLogic") then {
-        bmt_var_centreSideLogic = createCenter sideLogic;
-        bmt_var_groupSideLogic = createGroup bmt_var_centreSideLogic;
-    };
-    bmt_var_dacModule = bmt_var_groupSideLogic createUnit ["DAC_Source_Extern", [0,0,0],[], 1,"NONE"];
-    publicVariable "bmt_var_dacModule";
+if (!isServer) exitWith { };
 
-    // Initialise the variable "DAC_STRPlayers" with the names of all playable units. It is necessary that
-    // all playable units have an associated name.
-    DAC_STRPlayers = [];
-    {
-        DAC_STRPlayers pushBack format ["%1",_x];
-    } forEach playableUnits;
-    publicVariable "DAC_STRPlayers";
+// Create DAC necessary "DAC_Source_Extern" logic module.
+if (isNil "bmt_var_centreSideLogic") then {
+    bmt_var_centreSideLogic = createCenter sideLogic;
+    bmt_var_groupSideLogic = createGroup bmt_var_centreSideLogic;
+};
+bmt_var_dacModule = bmt_var_groupSideLogic createUnit ["DAC_Source_Extern", [0,0,0],[], 1,"NONE"];
+publicVariable "bmt_var_dacModule";
 
-    if (bmt_param_debugOutput == 1) then {
-        player sideChat format ["DEBUG (fn_dac_init.sqf): %1", DAC_STRPlayers];
-    };
+// Initialise the variable "DAC_STRPlayers" with the names of all playable units. It is necessary that
+// all playable units have an associated name.
+DAC_STRPlayers = [];
+{
+    DAC_STRPlayers pushBack format ["%1",_x];
+} forEach playableUnits;
+publicVariable "DAC_STRPlayers";
+
+if (bmt_param_debugOutput == 1) then {
+    player sideChat format ["DEBUG (fn_dac_init.sqf): %1", DAC_STRPlayers];
 };
 
 // Modify DAC output depending whether the debug is activated or not.
@@ -63,5 +63,9 @@ switch (bmt_param_dac_debug) do {
         player sideChat format ["DEBUG (fn_dac_init.sqf): Unrecognised DAC parameter."];
     };
 };
+
+// Make the variables public
+publicVariable "DAC_Com_Values";
+publicVariable "DAC_Marker";
 
 //============================================= END OF FILE =============================================//

--- a/src/jip/functions/fn_jip_retrievePlayerVariables.sqf
+++ b/src/jip/functions/fn_jip_retrievePlayerVariables.sqf
@@ -24,15 +24,13 @@ params["_unit", "_jipPlayerVariables"];
 
 // Handle advanced fatigue
 if (bmt_mod_ace3) then {
-    ace_advanced_fatigue_ae1Reserve = _unit getVariable ["bmt_var_ace_advancedfatigue_ae1Reserve", nil];
-    ace_advanced_fatigue_ae2Reserve = _unit getVariable ["bmt_var_ace_advancedfatigue_ae2Reserve", nil];
-    ace_advanced_fatigue_anReserve = _unit getVariable ["bmt_var_ace_advancedfatigue_anReserve", nil];
-    ace_advanced_fatigue_anFatigue = _unit getVariable ["bmt_var_ace_advancedfatigue_anFatigue", nil];
-    ace_advanced_fatigue_muscleDamage = _unit getVariable ["bmt_var_ace_advancedfatigue_muscleDamage", nil];
+    {
+        call compile format ["%1 = %2;", _x select 0, _x select 1];
+    } forEach (_unit getVariable ["bmt_var_ace_advancedfatigue", nil]);
 };
 
 if (bmt_param_debugOutput == 1) then {
-    diag_log  format ["DEBUG (fn_jip_retrievePlayerVariables.sqf): Previous status successfully restored %1, %2, %3, %4", _unit getVariable ["bmt_var_ace_advancedfatigue_ae1Reserve", nil], _unit getVariable ["bmt_var_ace_advancedfatigue_ae2Reserve", nil], _unit getVariable ["bmt_var_ace_advancedfatigue_anReserve", nil], _unit getVariable ["bmt_var_ace_advancedfatigue_anFatigue", nil]];
+    diag_log  format ["DEBUG (fn_jip_retrievePlayerVariables.sqf): Previous status successfully restored."];
 };
 
 player setVariable ["bmt_var_jip_StatusRetrieved", true];

--- a/src/jip/functions/fn_jip_saveStatus_AdvancedFatigue.sqf
+++ b/src/jip/functions/fn_jip_saveStatus_AdvancedFatigue.sqf
@@ -13,11 +13,14 @@
 //=======================================================================================================//
 
 params ["_unit"];
+private ["_ace_advancedfatigue"];
 
-_unit setVariable ["bmt_var_ace_advancedfatigue_ae1Reserve", ace_advanced_fatigue_ae1Reserve, true];
-_unit setVariable ["bmt_var_ace_advancedfatigue_ae2Reserve", ace_advanced_fatigue_ae2Reserve, true];
-_unit setVariable ["bmt_var_ace_advancedfatigue_anReserve", ace_advanced_fatigue_anReserve, true];
-_unit setVariable ["bmt_var_ace_advancedfatigue_anFatigue", ace_advanced_fatigue_anFatigue, true];
-_unit setVariable ["bmt_var_ace_advancedfatigue_muscleDamage", ace_advanced_fatigue_muscleDamage, true];
+_ace_advancedfatigue = [];
+_ace_advancedfatigue pushback ["ace_advanced_fatigue_ae1Reserve", ace_advanced_fatigue_ae1Reserve];
+_ace_advancedfatigue pushback ["ace_advanced_fatigue_ae2Reserve", ace_advanced_fatigue_ae2Reserve];
+_ace_advancedfatigue pushback ["ace_advanced_fatigue_anReserve", ace_advanced_fatigue_anReserve];
+_ace_advancedfatigue pushback ["ace_advanced_fatigue_anFatigue", ace_advanced_fatigue_anFatigue];
+_ace_advancedfatigue pushback ["ace_advanced_fatigue_muscleDamage", ace_advanced_fatigue_muscleDamage];
 
+_unit setVariable ["bmt_var_ace_advancedfatigue", _ace_advancedfatigue, true];
 //============================================= END OF FILE =============================================//

--- a/src/jip/scripts/bmt_jip_init.sqf
+++ b/src/jip/scripts/bmt_jip_init.sqf
@@ -76,6 +76,9 @@ if (hasInterface) then {
             } else {
                 // Player is already defined. Therefore, he is reconnecting.
                 if (bmt_param_jip_saveStatus == 1) then {
+                    if (isClass (configFile >> "CfgPatches" >> "ace_advanced_fatigue")) then {
+                        waitUntil {!isNil "ace_advanced_fatigue_ae1Reserve"};
+                    };
                     [player] call bmt_fnc_jip_retrieveStatus;
                 };
             };

--- a/src/respawn/functions/fn_respawn_enterSpectator.sqf
+++ b/src/respawn/functions/fn_respawn_enterSpectator.sqf
@@ -15,16 +15,16 @@
 
 params [["_respawnUnit",objNull], ["_spectableUnit",objNull]];
 
-// Hide seagull body.
-if (_respawnUnit isKindOf "seagull") then {
-    if (bmt_mod_ace3 && (bmt_param_ace3_spectator ==  1)) then {
-        _spectableUnit = selectRandom playableUnits;
-        [_respawnUnit] call ace_spectator_fnc_stageSpectator;
-    };
-};
+
 
 // If ACE 3 is loaded use the spectator mode of ACE3. Use the vanila one otherwise (End Game Spectator).
 if (bmt_mod_ace3 && (bmt_param_ace3_spectator ==  1)) then {
+
+    // Hide seagull body.
+    if (_respawnUnit isKindOf "seagull") then {
+        [_respawnUnit] call ace_spectator_fnc_stageSpectator;
+    };
+
     if ( bmt_param_debugOutput == 1) then {
         player sideChat format ["DEBUG (bmt_respawn_onPlayerRespawn.sqf): Using ACE3 spectator mode."];
     };
@@ -52,7 +52,7 @@ if (bmt_mod_ace3 && (bmt_param_ace3_spectator ==  1)) then {
     // Start the End Game Spectator.
     // - All sides can be viewed.
     // - The AI cannot be observed.
-    ["Initialize", [player, [], false]] call BIS_fnc_EGSpectator;
+    ["Initialize", [player, [], false, true, true, true, true, true, true, true]] call BIS_fnc_EGSpectator;
 };
 
 //============================================= END OF FILE =============================================//

--- a/src/tfar/functions/fn_tfar_configureChannels.sqf
+++ b/src/tfar/functions/fn_tfar_configureChannels.sqf
@@ -73,7 +73,7 @@ if (_unitGroup select 0 != "nil") then {
         {
             _frequencies = bmt_array_frequenciesLongRange select _forEachIndex;
             [(call TFAR_fnc_activeLrRadio), _channel + 1, format ["%1",_frequencies select 0]] call TFAR_fnc_SetChannelFrequency;
-            if ("Command" in _x) then {
+            if (bmt_var_tfar_commandingGroup in _x) then {
                 _commandChannel = _channel;
             };
             _channel = _channel + 1;

--- a/src/tfar/functions/fn_tfar_configureChannels.sqf
+++ b/src/tfar/functions/fn_tfar_configureChannels.sqf
@@ -26,7 +26,7 @@ if ((typeName _unitOptions) == "STRING") then {
     _unitRole = _unitOptions select 0; // First entry must always be the unit role
 };
 
-if ((_unitGroup select 0 != "nil") and (_unitGroup select 1 != -1)) then {
+if (_unitGroup select 0 != "nil") then {
 
     // Configure the frequencies of short range radios.
     if ((_unitRole in bmt_array_shortRangeRadio) or (_unitRole in bmt_array_riflemanRadio)) then {
@@ -57,8 +57,10 @@ if ((_unitGroup select 0 != "nil") and (_unitGroup select 1 != -1)) then {
 
         // Units with a radio superior to the "Rifleman Radio" have the additional channel configured. It
         // defaults to the squad channel.
-        if (_unitRole in bmt_array_shortRangeRadio) then {
-            [(call TFAR_fnc_activeSwRadio), _squadChannel] call TFAR_fnc_setAdditionalSwChannel;
+        if (_unitGroup select 1 != 0) then{
+            if (_unitRole in bmt_array_shortRangeRadio) then {
+                [(call TFAR_fnc_activeSwRadio), _squadChannel] call TFAR_fnc_setAdditionalSwChannel;
+            };
         };
     };
 


### PR DESCRIPTION
- Various fixes to the briefing: radio briefing is automatically configured.
- Improvements to enterSpectator code.
- Fixed debug output for ACE3 Revive.
- Fixed tfar channel configuration for groups of size 0
- Reduced amount of public variables in restoring advanced fatigue
- Fixed DAC when JIP
- Configuration of SEM 52 SL (ACRE 2)